### PR TITLE
Add SQL DDL validation script and resolve duplicate index name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ python data_migration.py \
 
 Use the plan output as a checklist: the script only moves data for columns with an unambiguous destination, leaving relationship fan-out and attribute reshaping to domain-specific ETL jobs.
 
+### Validating the DDL snapshots
+
+Run `tests/test_sql_files.py` to lint the SQL snapshots for duplicate object names and, when a PostgreSQL client is available, to execute the files inside a temporary transaction. The validator defaults to static analysis, which is useful in constrained CI environments that may not ship with `psql`.
+
+```bash
+# Static validation (checks for duplicate tables, indexes, and constraints)
+python3 tests/test_sql_files.py ddl.sql refactored_ddl.sql
+
+# Execute the DDL against a Postgres instance
+python3 tests/test_sql_files.py ddl.sql refactored_ddl.sql --execute --database-url postgresql://user:pass@localhost/postgres
+```
+
 ### Mapping flow script
 
 Run `./refactored_ddl.sh` to print an end-to-end mapping flow that walks each legacy table to its destination inside the refactored schema. The script mirrors the table above, but it also highlights when polymorphic join tables (`relationship_links`, `note_links`, etc.) absorb responsibilities that were previously handled by bespoke pivot tables. Because the mapping is generated programmatically, you can feed the output into documentation or migration tooling without reformatting by hand. See [`refactored_ddl_mapping.md`](refactored_ddl_mapping.md) for a narrative walkthrough of the script's output structure and usage tips.【F:refactored_ddl.sh†L1-L172】【F:refactored_ddl_mapping.md†L1-L46】

--- a/ddl.sql
+++ b/ddl.sql
@@ -1359,7 +1359,7 @@ CREATE TABLE variable_rates_history_copy1 (
   PRIMARY KEY (id),
   CONSTRAINT variable_rates_history_copy1_ibfk_1 FOREIGN KEY (variable_rate_source_id) REFERENCES variable_rate_sources (id) ON DELETE CASCADE
 );
-CREATE INDEX variable_rates_history_variable_rate_source_id_foreign ON variable_rates_history_copy1 (variable_rate_source_id);
+CREATE INDEX variable_rates_history_copy1_variable_rate_source_id_foreign ON variable_rates_history_copy1 (variable_rate_source_id);
 
 
 -- prod.lender_funder_interest_rate definition

--- a/tests/test_sql_files.py
+++ b/tests/test_sql_files.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Validate SQL DDL files and optionally execute them with ``psql``."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+SqlObjects = Dict[str, List[Tuple[str, int]]]
+
+CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?\"?([A-Za-z0-9_]+)\"?",
+    re.IGNORECASE,
+)
+CREATE_INDEX_RE = re.compile(
+    r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\"?([A-Za-z0-9_]+)\"?",
+    re.IGNORECASE,
+)
+ADD_CONSTRAINT_RE = re.compile(
+    r"ALTER\s+TABLE\s+.+\s+ADD\s+CONSTRAINT\s+\"?([A-Za-z0-9_]+)\"?",
+    re.IGNORECASE,
+)
+
+
+def _strip_inline_comment(line: str) -> str:
+    if "--" not in line:
+        return line
+    comment_start = line.index("--")
+    return line[:comment_start]
+
+
+def _collect_objects(path: Path) -> SqlObjects:
+    objects: SqlObjects = collections.defaultdict(list)
+    for line_no, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        line = _strip_inline_comment(raw_line).strip()
+        if not line:
+            continue
+        if match := CREATE_TABLE_RE.search(line):
+            objects["table"].append((match.group(1), line_no))
+        elif match := CREATE_INDEX_RE.search(line):
+            objects["index"].append((match.group(1), line_no))
+        elif match := ADD_CONSTRAINT_RE.search(line):
+            objects["constraint"].append((match.group(1), line_no))
+    return objects
+
+
+def find_duplicates(objects: SqlObjects) -> List[str]:
+    duplicates: List[str] = []
+    for obj_type, entries in objects.items():
+        names = [name for name, _ in entries]
+        counter = collections.Counter(names)
+        for name, count in counter.items():
+            if count > 1:
+                line_numbers = [str(line_no) for entry_name, line_no in entries if entry_name == name]
+                duplicates.append(
+                    f"Duplicate {obj_type} name '{name}' at lines {', '.join(line_numbers)}"
+                )
+    return duplicates
+
+
+def execute_with_psql(sql_path: Path, database_url: str) -> None:
+    if shutil.which("psql") is None:
+        raise RuntimeError("psql is not available on PATH. Install PostgreSQL client tools to execute DDL.")
+    cmd = [
+        "psql",
+        database_url,
+        "-v",
+        "ON_ERROR_STOP=1",
+        "--single-transaction",
+        "--file",
+        str(sql_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "sql_files",
+        nargs="+",
+        type=Path,
+        help="SQL files to validate",
+    )
+    parser.add_argument(
+        "--database-url",
+        help="Database URL passed directly to psql for execution.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the SQL files using psql after validation.",
+    )
+    args = parser.parse_args(argv)
+
+    any_errors = False
+    for sql_path in args.sql_files:
+        if not sql_path.exists():
+            print(f"[ERROR] {sql_path} does not exist", file=sys.stderr)
+            any_errors = True
+            continue
+        objects = _collect_objects(sql_path)
+        duplicates = find_duplicates(objects)
+        if duplicates:
+            any_errors = True
+            print(f"[FAIL] {sql_path}: found duplicate object names:")
+            for message in duplicates:
+                print(f"        - {message}")
+        else:
+            print(f"[OK] {sql_path}: no duplicate object names detected.")
+
+        if args.execute and not duplicates:
+            if not args.database_url:
+                print("[ERROR] --execute requires --database-url", file=sys.stderr)
+                any_errors = True
+            else:
+                try:
+                    execute_with_psql(sql_path, args.database_url)
+                except subprocess.CalledProcessError as exc:
+                    any_errors = True
+                    print(f"[FAIL] Execution failed for {sql_path}: {exc}", file=sys.stderr)
+                except RuntimeError as exc:
+                    any_errors = True
+                    print(f"[FAIL] {exc}", file=sys.stderr)
+
+    return 1 if any_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a lightweight validator that scans SQL files for duplicate object names and can optionally execute them via `psql`
- fix the duplicate index name in `ddl.sql` so both history tables have distinct identifiers
- document how to run the new validator alongside the existing tooling in the README

## Testing
- python3 tests/test_sql_files.py ddl.sql refactored_ddl.sql

------
https://chatgpt.com/codex/tasks/task_e_68e418ac2fc48320980265b2cb2d7ead